### PR TITLE
Merging the code developments done during John's vacation

### DIFF
--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -760,22 +760,10 @@ public class HCALEventHandler extends UserEventHandler {
     String selectedRun = ((StringT)functionManager.getParameterSet().get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
     logger.info("[HCAL " + functionManager.FMname + "]: The selected snippet was: " + selectedRun);    
     try{
-        docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-        if (selectedRun == "not set" ) {
-          logger.info("[HCAL " + functionManager.FMname + "]: This FM did not get the selected run. It will now look for one from the LVL1");
-          ParameterSet<FunctionManagerParameter> parameterSet = getUserFunctionManager().getParameterSet();
-          selectedRun = ((StringT)parameterSet.get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-          logger.info("[HCAL " + functionManager.FMname + "]: This FM looked for the selected run from the LVL1 and got: " + selectedRun);
-          if (selectedRun == "not set") {
-            ParameterSet<CommandParameter> commandParameterSet = getUserFunctionManager().getLastInput().getParameterSet();
-            selectedRun = ((StringT)commandParameterSet.get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-            logger.info("[HCAL " + functionManager.FMname + "]: This FM looked again for the selected run from the LVL1 and got: " + selectedRun);
-          }
-        }
         String TagName = "TTCciControl";
         tmpTTCciControlSequence = xmlHandler.getHCALControlSequence(selectedRun,CfgCVSBasePath,TagName);
     }
-    catch ( ParserConfigurationException |  UserActionException e) {
+    catch (  UserActionException e) {
           logger.error("[HCAL " + functionManager.FMname + "]: Got a error when parsing the TTCciControl xml: " + e.getMessage());
     }
     FullTTCciControlSequence = tmpTTCciControlSequence;

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -503,8 +503,8 @@ public class HCALEventHandler extends UserEventHandler {
 
     // Get the CfgCVSBasePath in the userXML
     {
-      //String DefaultCfgCVSBasePath = "/nfshome0/hcalcfg/cvs/RevHistory/";
-      String DefaultCfgCVSBasePath = "/data/cfgcvs/cvs/RevHistory/";
+      String DefaultCfgCVSBasePath = "/nfshome0/hcalcfg/cvs/RevHistory/";
+      //String DefaultCfgCVSBasePath = "/data/cfgcvs/cvs/RevHistory/";
       String theCfgCVSBasePath = "";
       try { theCfgCVSBasePath=xmlHandler.getHCALuserXMLelementContent("CfgCVSBasePath"); }
       catch (UserActionException e) { logger.warn(e.getMessage()); }
@@ -1166,10 +1166,9 @@ public class HCALEventHandler extends UserEventHandler {
           logger.debug("[HCAL " + functionManager.FMname + "]: the FM with name: " + qr.getName() + " has a resource named " + level2resource.getName() );
           if (!MaskedFMs.contains(qr.getName())) { 
             if (!allMaskedResources.contains(qr.getName()) && (level2resource.getName().contains("TriggerAdapter") || level2resource.getName().contains("FanoutTTCciTA")))          {
-              if (somebodysHandlingTA && !itsAdummy) { 
-                if (level2resource.getName().contains("DummyTriggerAdapter") ) {
-                  itsThisLvl2=true;
-                  itsAdummy=true;
+              if (somebodysHandlingTA ) { 
+                if (level2resource.getName().contains("DummyTriggerAdapter") && !EvmTrigsApps.contains("DummyTriggerAdapter")) {
+                 // itsAdummy=true;
                   logger.warn("[JohnLog] found a DummyTriggerAdapter in " + qr.getName() + " after somebody else is already handling the TA.");
                   allMaskedResources += EvmTrigsApps;
                   qr.getResource().setRole("EvmTrig");
@@ -1181,6 +1180,7 @@ public class HCALEventHandler extends UserEventHandler {
                     if (otherLevel2FM.getRole().toString().equals("EvmTrig") && !qr.getName().equals(otherLevel2FM.getName())) {
                        otherLevel2FM.getResource().setRole("HCAL");
                        logger.warn("[JohnLog] just reset the role HCAL for the FM with name: "  + otherLevel2FM.getName());
+                       itsThisLvl2=true;
                        functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.EVM_TRIG_FM, new StringT(qr.getName())));
                        logger.warn("[JohnLog] just reset the role EVM_TRIG_FM");
                     }
@@ -1197,9 +1197,9 @@ public class HCALEventHandler extends UserEventHandler {
                 logger.info("[HCAL " + functionManager.FMname + "]: The following FM is handling the trigger adapter: " + qr.getName());
                 somebodysHandlingTA=true;
                 itsThisLvl2=true;
-                if (qr.getName().contains("DummyTriggerAdapter")){
-                  itsAdummy = true;
-                }
+               // if (qr.getName().contains("DummyTriggerAdapter")){
+               //   itsAdummy = true;
+              //  }
                 logger.debug("[HCAL " + functionManager.FMname + "]: About to set EVM_TRIG_FM.");
                 functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.EVM_TRIG_FM, new StringT(qr.getName())));
                 logger.info("[HCAL " + functionManager.FMname + "]: Just set EVM_TRIG_FM.");

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -502,22 +502,22 @@ public class HCALEventHandler extends UserEventHandler {
     }
 
     // Get the CfgCVSBasePath in the userXML
-    //{
-    //  //String DefaultCfgCVSBasePath = "/nfshome0/hcalcfg/cvs/RevHistory/";
-    //  String DefaultCfgCVSBasePath = "/data/cfgcvs/cvs/RevHistory/";
-    //  String theCfgCVSBasePath = "";
-    //  try { theCfgCVSBasePath=xmlHandler.getHCALuserXMLelementContent("CfgCVSBasePath"); }
-    //  catch (UserActionException e) { logger.warn(e.getMessage()); }
-    //  if (!theCfgCVSBasePath.equals("")) {
-    //    CfgCVSBasePath = theCfgCVSBasePath;
-    //  } else{
-    //    CfgCVSBasePath = DefaultCfgCVSBasePath;
-    //  }
-    //  //logger.debug("[HCAL base] CfgCVSBasePath: " +CfgCVSBasePath + " is used.");
-    //  logger.info("[HCAL base] CfgCVSBasePath: " +CfgCVSBasePath + " is used.");
-    // 
-    //  
-    //}
+    {
+      //String DefaultCfgCVSBasePath = "/nfshome0/hcalcfg/cvs/RevHistory/";
+      String DefaultCfgCVSBasePath = "/data/cfgcvs/cvs/RevHistory/";
+      String theCfgCVSBasePath = "";
+      try { theCfgCVSBasePath=xmlHandler.getHCALuserXMLelementContent("CfgCVSBasePath"); }
+      catch (UserActionException e) { logger.warn(e.getMessage()); }
+      if (!theCfgCVSBasePath.equals("")) {
+        CfgCVSBasePath = theCfgCVSBasePath;
+      } else{
+        CfgCVSBasePath = DefaultCfgCVSBasePath;
+      }
+      //logger.debug("[HCAL base] CfgCVSBasePath: " +CfgCVSBasePath + " is used.");
+      logger.info("[HCAL base] CfgCVSBasePath: " +CfgCVSBasePath + " is used.");
+     
+      
+    }
 
     // Check if a default ZeroSuppressionSnippetName is given in the userXML
     {
@@ -690,8 +690,8 @@ public class HCALEventHandler extends UserEventHandler {
             logger.info("[HCAL " + functionManager.FMname + "]: This FM looked again for the selected run from the LVL1 and got: " + selectedRun);
           }
         } 
-        Document masterSnippet = docBuilder.parse(new File("/data/cfgcvs/cvs/RevHistory/" + selectedRun + "/pro"));
-        //Document masterSnippet = docBuilder.parse(new File( CfgCVSBasePath + selectedRun + "/pro"));
+        //Document masterSnippet = docBuilder.parse(new File("/data/cfgcvs/cvs/RevHistory/" + selectedRun + "/pro"));
+        Document masterSnippet = docBuilder.parse(new File( CfgCVSBasePath + selectedRun + "/pro"));
 
         masterSnippet.getDocumentElement().normalize();
         DOMSource domSource = new DOMSource(masterSnippet);
@@ -756,11 +756,11 @@ public class HCALEventHandler extends UserEventHandler {
   // can be done directly in the userXML.
   protected void getTTCciControl() {
     String tmpTTCciControlSequence="";
-    try{
+    //try{
         // Load the master snippet from the found file and parse it.
         String selectedRun = ((StringT)functionManager.getParameterSet().get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
         logger.info("[HCAL " + functionManager.FMname + "]: The selected snippet was: " + selectedRun);    
-
+      try{
         docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
         if (selectedRun == "not set" ) {
           logger.info("[HCAL " + functionManager.FMname + "]: This FM did not get the selected run. It will now look for one from the LVL1");
@@ -772,38 +772,42 @@ public class HCALEventHandler extends UserEventHandler {
             selectedRun = ((StringT)commandParameterSet.get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
             logger.info("[HCAL " + functionManager.FMname + "]: This FM looked again for the selected run from the LVL1 and got: " + selectedRun);
           }
-        } 
-        Document masterSnippet = docBuilder.parse(new File(CfgCVSBasePath + selectedRun + "/pro"));
-
-        masterSnippet.getDocumentElement().normalize();
-        DOMSource domSource = new DOMSource(masterSnippet);
-        StringWriter writer = new StringWriter();
-        StreamResult result = new StreamResult(writer);
-        TransformerFactory tf = TransformerFactory.newInstance();
-        Transformer transformer = tf.newTransformer();
-        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-        transformer.transform(domSource, result);
-
-        NodeList TTCciControl =  masterSnippet.getDocumentElement().getElementsByTagName("TTCciControl");
-        logger.info("[HCAL " + functionManager.FMname + "]: The TTCcoControl has this in it:");
-        logger.info("[HCAL " + functionManager.FMname + "]: ---------------------------");
-        String TTCciControlDoc = TTCciControl.item(0).getTextContent();
-        logger.info(TTCciControlDoc);
-        logger.info("[HCAL " + functionManager.FMname + "]: ---------------------------");
-
-        for(int iFile=0; iFile< TTCciControl.getLength() ; iFile++){
-           Node iNode = TTCciControl.item(iFile);
-           Element iElement = (Element) iNode;
-           if (iElement.getTagName()=="include"){
-               String fname = CfgCVSBasePath + iElement.getAttribute("file").substring(1)+"/pro";
-               tmpTTCciControlSequence += readTextFile(fname);
-           }
         }
-    }
-    catch (TransformerException | DOMException | ParserConfigurationException | SAXException | IOException e) {
-        logger.error("[HCAL " + functionManager.FMname + "]: Got a error when parsing the TTCciControl xml: " + e.getMessage());
-    }
+          String TagName = "TTCciControl";
+          tmpTTCciControlSequence = xmlHandler.getHCALControlSequence(selectedRun,CfgCVSBasePath,TagName);
+       }
+       catch (  ParserConfigurationException |  UserActionException e) {
+          logger.error("[HCAL " + functionManager.FMname + "]: Got a error when parsing the TTCciControl xml: " + e.getMessage());
+       }
+        
+      //  Document masterSnippet = docBuilder.parse(new File(CfgCVSBasePath + selectedRun + "/pro"));
+
+      //  masterSnippet.getDocumentElement().normalize();
+      //  DOMSource domSource = new DOMSource(masterSnippet);
+      //  StringWriter writer = new StringWriter();
+      //  StreamResult result = new StreamResult(writer);
+      //  TransformerFactory tf = TransformerFactory.newInstance();
+      //  Transformer transformer = tf.newTransformer();
+      //  transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+      //  transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+      //  transformer.transform(domSource, result);
+
+      //  NodeList TTCciControl =  masterSnippet.getDocumentElement().getElementsByTagName("TTCciControl");
+      //  logger.info("[Martin log HCAL " + functionManager.FMname + "]: Found " + TTCciControl.getLength()+" TTCciControl nodes ");
+
+      //  Element  el = (Element) TTCciControl.item(0);
+      //  NodeList childlist = el.getElementsByTagName("include");
+      //  logger.info("[Martin log HCAL " + functionManager.FMname + "]: Found " + childlist.getLength()+" cfg to read");
+      //  for(int i =0;i< childlist.getLength();i++){
+      //      Element iElement = (Element) childlist.item(i);
+      //      String fname = CfgCVSBasePath + iElement.getAttribute("file").substring(1)+"/pro";
+		  //      logger.info("Martin log [HCAL " + functionManager.FMname + "]: Going to read the file of this node from " + fname) ;
+      //      tmpTTCciControlSequence += readTextFile(fname); 
+      //  }
+      //}
+      //catch (TransformerException | DOMException | ParserConfigurationException | SAXException | IOException e) {
+      //    logger.error("[HCAL " + functionManager.FMname + "]: Got a error when parsing the TTCciControl xml: " + e.getMessage());
+      //}
     FullTTCciControlSequence = tmpTTCciControlSequence;
     logger.info("[Martin Log HCAL " + functionManager.FMname + "] The FullTTCciControlSequence which was successfully compiled for this FM.\nIt looks like this:\n" + FullTTCciControlSequence);
     functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.HCAL_TTCCICONTROL,new StringT(FullTTCciControlSequence)));

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -1736,22 +1736,22 @@ public class HCALEventHandler extends UserEventHandler {
     }
 
 
-    // finally, halt LPM
-		XdaqApplication lpmApp = null;
+    // finally, halt all TCDS apps
     try {
-      Iterator it = functionManager.containerlpmController.getQualifiedResourceList().iterator();
+      Iterator it = functionManager.containerTCDSControllers.getQualifiedResourceList().iterator();
+      XdaqApplication tcdsApp = null;
       while (it.hasNext()) {
-				lpmApp = (XdaqApplication) it.next();
-				logger.warn("[HCAL " + functionManager.FMname + "] HALT TCDS application: " + lpmApp.getName() + " class: " + lpmApp.getClass() + " instance: " + lpmApp.getInstance());
+				tcdsApp = (XdaqApplication) it.next();
+				logger.warn("[HCAL " + functionManager.FMname + "] HALT TCDS application: " + tcdsApp.getName() + " class: " + tcdsApp.getClass() + " instance: " + tcdsApp.getInstance());
         //SIC TODO FIXME: use real session ID (and possibly RCMS URL) here
         // SIC TODO XXX FIXME Why doesn't this work?
 				//tcdsApp.execute(HCALInputs.HALT,"test","http://dev.null:10000");
-				lpmApp.execute(HCALInputs.HALT,"test","http://cmsrc-hcal.cms:16001/rcms");
+				tcdsApp.execute(HCALInputs.HALT,"test","http://cmsrc-hcal.cms:16001/rcms");
 			}
     }
     catch (Exception e) {
       // failed to halt
-      String errMessage = "[HCAL " + functionManager.FMname + "] " + this.getClass().toString() + " failed to HALT TCDS application: " + lpmApp.getName() + " class: " + lpmApp.getClass() + " instance: " + lpmApp.getInstance();
+      String errMessage = "[HCAL " + functionManager.FMname + "] " + this.getClass().toString() + " failed to HALT TCDS applications";
       logger.error(errMessage,e);
       functionManager.sendCMSError(errMessage);
       functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.STATE,new StringT("Error")));

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -872,7 +872,7 @@ public class HCALEventHandler extends UserEventHandler {
     logger.info("[Martin log HCAL " + functionManager.FMname + "]: This FM is going to parse FedEnableMask from : " +CfgCVSBasePath+ selectedRun+"/pro");    
     try{
         String TagName = "FedEnableMask";
-        FedEnableMask = xmlHandler.getHCALControlSequence(selectedRun,CfgCVSBasePath,TagName);
+        FedEnableMask = xmlHandler.getHCALMasterSnippetTag(selectedRun,CfgCVSBasePath,TagName);
     }
     catch ( UserActionException e) {
           logger.error("[Martin log HCAL " + functionManager.FMname + "]: Got a error when parsing the FedEnableMask in getFedEnableMask(): " + e.getMessage());

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -1748,22 +1748,22 @@ public class HCALEventHandler extends UserEventHandler {
     }
 
 
-    // finally, halt all TCDS apps
+    // finally, halt LPM
+		XdaqApplication lpmApp = null;
     try {
-      Iterator it = functionManager.containerTCDSControllers.getQualifiedResourceList().iterator();
-      XdaqApplication tcdsApp = null;
+      Iterator it = functionManager.containerlpmController.getQualifiedResourceList().iterator();
       while (it.hasNext()) {
-				tcdsApp = (XdaqApplication) it.next();
-				logger.warn("[HCAL " + functionManager.FMname + "] HALT TCDS application: " + tcdsApp.getName() + " class: " + tcdsApp.getClass() + " instance: " + tcdsApp.getInstance());
+				lpmApp = (XdaqApplication) it.next();
+				logger.warn("[HCAL " + functionManager.FMname + "] HALT TCDS application: " + lpmApp.getName() + " class: " + lpmApp.getClass() + " instance: " + lpmApp.getInstance());
         //SIC TODO FIXME: use real session ID (and possibly RCMS URL) here
         // SIC TODO XXX FIXME Why doesn't this work?
 				//tcdsApp.execute(HCALInputs.HALT,"test","http://dev.null:10000");
-				tcdsApp.execute(HCALInputs.HALT,"test","http://cmsrc-hcal.cms:16001/rcms");
+				lpmApp.execute(HCALInputs.HALT,"test","http://cmsrc-hcal.cms:16001/rcms");
 			}
     }
     catch (Exception e) {
       // failed to halt
-      String errMessage = "[HCAL " + functionManager.FMname + "] " + this.getClass().toString() + " failed to HALT TCDS applications";
+      String errMessage = "[HCAL " + functionManager.FMname + "] " + this.getClass().toString() + " failed to HALT TCDS application: " + lpmApp.getName() + " class: " + lpmApp.getClass() + " instance: " + lpmApp.getInstance();
       logger.error(errMessage,e);
       functionManager.sendCMSError(errMessage);
       functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.STATE,new StringT("Error")));

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -736,7 +736,8 @@ public class HCALEventHandler extends UserEventHandler {
         logger.debug("[HCAL " + functionManager.FMname + "]: ---------------------------");
         logger.debug(xmlString);
         logger.debug("[HCAL " + functionManager.FMname + "]: ---------------------------");
-        configString = xmlString;
+        //configString = xmlString;
+        configString = ConfigDoc;
       }
       catch (TransformerException e) {
         logger.error("[HCAL " + functionManager.FMname + "]: Got a TransformerException when trying to transform modified mastersnippet xml: " + e.getMessage());
@@ -992,8 +993,9 @@ public class HCALEventHandler extends UserEventHandler {
             else {
               pam.select(new String[] {"RunType", "ConfigurationDoc", "Partition", "RunSessionNumber", "hardwareConfigurationStringTCDS", "hardwareConfigurationStringLPM", "hardwareConfigurationStringPI", "fedEnableMask", "usePrimaryTCDS"});
               pam.setValue("RunType",functionManager.FMfullpath);
-              logger.info("[HCAL " + functionManager.FMname + "]: the ConfigurationDoc to be sent to the supervisor is: " + ConfigDoc);
-              pam.setValue("ConfigurationDoc",ConfigDoc);
+              logger.info("[HCAL " + functionManager.FMname + "]: the ConfigurationDoc to be sent to the supervisor is: " + CfgScript);
+              //pam.setValue("ConfigurationDoc",ConfigDoc);
+              pam.setValue("ConfigurationDoc",CfgScript);
               pam.setValue("Partition",functionManager.FMpartition);
               pam.setValue("RunSessionNumber",Sid.toString());
               pam.setValue("hardwareConfigurationStringTCDS", FullTCDSControlSequence);

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -756,15 +756,14 @@ public class HCALEventHandler extends UserEventHandler {
   // can be done directly in the userXML.
   protected void getTTCciControl() {
     String tmpTTCciControlSequence="";
-    // Load the master snippet from the found file and parse it.
     String selectedRun = ((StringT)functionManager.getParameterSet().get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-    logger.info("[HCAL " + functionManager.FMname + "]: The selected snippet was: " + selectedRun);    
+    logger.info("[HCAL " + functionManager.FMname + "]: This FM is going to parse TTCciControl seqence from : " +CfgCVSBasePath+ selectedRun+"/pro");    
     try{
         String TagName = "TTCciControl";
         tmpTTCciControlSequence = xmlHandler.getHCALControlSequence(selectedRun,CfgCVSBasePath,TagName);
     }
     catch (  UserActionException e) {
-          logger.error("[HCAL " + functionManager.FMname + "]: Got a error when parsing the TTCciControl xml: " + e.getMessage());
+          logger.error("[HCAL " + functionManager.FMname + "]: Got a error when parsing the TTCciControl xml in getTTCciControl: " + e.getMessage());
     }
     FullTTCciControlSequence = tmpTTCciControlSequence;
     logger.info("[Martin Log HCAL " + functionManager.FMname + "] The FullTTCciControlSequence which was successfully compiled for this FM.\nIt looks like this:\n" + FullTTCciControlSequence);
@@ -776,30 +775,17 @@ public class HCALEventHandler extends UserEventHandler {
   // can be done directly in the userXML.
   protected void getLTCControl() {
     String tmpLTCControlSequence="";
-    // Load the master snippet from the found file and parse it.
     String selectedRun = ((StringT)functionManager.getParameterSet().get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-    logger.info("[HCAL " + functionManager.FMname + "]: The selected snippet was: " + selectedRun);    
+    logger.info("[Martin log HCAL " + functionManager.FMname + "]: This FM is going to parse LTCControl seqence from : " +CfgCVSBasePath+ selectedRun+"/pro");    
     try{
-        docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-        if (selectedRun == "not set" ) {
-          logger.info("[HCAL " + functionManager.FMname + "]: This FM did not get the selected run. It will now look for one from the LVL1");
-          ParameterSet<FunctionManagerParameter> parameterSet = getUserFunctionManager().getParameterSet();
-          selectedRun = ((StringT)parameterSet.get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-          logger.info("[HCAL " + functionManager.FMname + "]: This FM looked for the selected run from the LVL1 and got: " + selectedRun);
-          if (selectedRun == "not set") {
-            ParameterSet<CommandParameter> commandParameterSet = getUserFunctionManager().getLastInput().getParameterSet();
-            selectedRun = ((StringT)commandParameterSet.get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-            logger.info("[HCAL " + functionManager.FMname + "]: This FM looked again for the selected run from the LVL1 and got: " + selectedRun);
-          }
-        }
         String TagName = "LTCControl";
         tmpLTCControlSequence = xmlHandler.getHCALControlSequence(selectedRun,CfgCVSBasePath,TagName);
     }
-    catch ( ParserConfigurationException |  UserActionException e) {
-          logger.error("[HCAL " + functionManager.FMname + "]: Got a error when parsing the LTCControl xml: " + e.getMessage());
+    catch ( UserActionException e) {
+          logger.error("[Martin logHCAL " + functionManager.FMname + "]: Got a error when parsing the LTCControl xml in getLTCControl: " + e.getMessage());
     }
     FullLTCControlSequence = tmpLTCControlSequence;
-    logger.info("[Martin Log HCAL " + functionManager.FMname + "] The FullLTCControlSequence which was successfully compiled for this FM.\nIt looks like this:\n" + FullLTCControlSequence);
+    logger.info("[Martin log HCAL " + functionManager.FMname + "] The FullLTCControlSequence which was successfully compiled for this FM.\nIt looks like this:\n" + FullLTCControlSequence);
 
     functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.HCAL_LTCCONTROL,new StringT(FullLTCControlSequence)));
   }
@@ -809,30 +795,17 @@ public class HCALEventHandler extends UserEventHandler {
   // can be done directly in the userXML.
   protected void getTCDSControl() {
     String tmpTCDSControlSequence="";
-    // Load the master snippet from the found file and parse it.
     String selectedRun = ((StringT)functionManager.getParameterSet().get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-    logger.info("[HCAL " + functionManager.FMname + "]: The selected snippet was: " + selectedRun);    
+    logger.info("[Martin log HCAL " + functionManager.FMname + "]: This FM is going to parse TCDSControl seqence from : " +CfgCVSBasePath+ selectedRun+"/pro");    
     try{
-        docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-        if (selectedRun == "not set" ) {
-          logger.info("[HCAL " + functionManager.FMname + "]: This FM did not get the selected run. It will now look for one from the LVL1");
-          ParameterSet<FunctionManagerParameter> parameterSet = getUserFunctionManager().getParameterSet();
-          selectedRun = ((StringT)parameterSet.get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-          logger.info("[HCAL " + functionManager.FMname + "]: This FM looked for the selected run from the LVL1 and got: " + selectedRun);
-          if (selectedRun == "not set") {
-            ParameterSet<CommandParameter> commandParameterSet = getUserFunctionManager().getLastInput().getParameterSet();
-            selectedRun = ((StringT)commandParameterSet.get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-            logger.info("[HCAL " + functionManager.FMname + "]: This FM looked again for the selected run from the LVL1 and got: " + selectedRun);
-          }
-        }
         String TagName = "TCDSControl";
         tmpTCDSControlSequence = xmlHandler.getHCALControlSequence(selectedRun,CfgCVSBasePath,TagName);
     }
-    catch ( ParserConfigurationException |  UserActionException e) {
-          logger.error("[HCAL " + functionManager.FMname + "]: Got a error when parsing the TCDSControl xml: " + e.getMessage());
+    catch ( UserActionException e) {
+          logger.error("[Martin log HCAL " + functionManager.FMname + "]: Got a error when parsing the TCDSControl xml in getTCDSControl(): " + e.getMessage());
     }
     FullTCDSControlSequence = tmpTCDSControlSequence;
-    logger.info("[Martin Log HCAL " + functionManager.FMname + "] The FullTCDSControlSequence which was successfully compiled for this FM.\nIt looks like this:\n" + FullTCDSControlSequence);
+    logger.info("[Martin log HCAL " + functionManager.FMname + "] The FullTCDSControlSequence which was successfully compiled for this FM.\nIt looks like this:\n" + FullTCDSControlSequence);
 
     functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.HCAL_TTCCICONTROL,new StringT(FullTCDSControlSequence)));
   }
@@ -842,30 +815,17 @@ public class HCALEventHandler extends UserEventHandler {
   // can be done directly in the userXML.
   protected void getLPMControl() {
     String tmpLPMControlSequence="";
-    // Load the master snippet from the found file and parse it.
     String selectedRun = ((StringT)functionManager.getParameterSet().get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-    logger.info("[HCAL " + functionManager.FMname + "]: The selected snippet was: " + selectedRun);    
+    logger.info("[Martin log HCAL " + functionManager.FMname + "]: This FM is going to parse LPMControl seqence from : " +CfgCVSBasePath+ selectedRun+"/pro");    
     try{
-        docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-        if (selectedRun == "not set" ) {
-          logger.info("[HCAL " + functionManager.FMname + "]: This FM did not get the selected run. It will now look for one from the LVL1");
-          ParameterSet<FunctionManagerParameter> parameterSet = getUserFunctionManager().getParameterSet();
-          selectedRun = ((StringT)parameterSet.get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-          logger.info("[HCAL " + functionManager.FMname + "]: This FM looked for the selected run from the LVL1 and got: " + selectedRun);
-          if (selectedRun == "not set") {
-            ParameterSet<CommandParameter> commandParameterSet = getUserFunctionManager().getLastInput().getParameterSet();
-            selectedRun = ((StringT)commandParameterSet.get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-            logger.info("[HCAL " + functionManager.FMname + "]: This FM looked again for the selected run from the LVL1 and got: " + selectedRun);
-          }
-        }
         String TagName = "LPMControl";
         tmpLPMControlSequence = xmlHandler.getHCALControlSequence(selectedRun,CfgCVSBasePath,TagName);
     }
-    catch ( ParserConfigurationException |  UserActionException e) {
-          logger.error("[HCAL " + functionManager.FMname + "]: Got a error when parsing the LPMControl xml: " + e.getMessage());
+    catch ( UserActionException e) {
+          logger.error("[Martin log HCAL " + functionManager.FMname + "]: Got a error when parsing the LPMControl xml in getLPMControl(): " + e.getMessage());
     }
     FullLPMControlSequence = tmpLPMControlSequence;
-    logger.info("[Martin Log HCAL " + functionManager.FMname + "] The FullLPMControlSequence which was successfully compiled for this FM.\nIt looks like this:\n" + FullLPMControlSequence);
+    logger.info("[Martin log HCAL " + functionManager.FMname + "] The FullLPMControlSequence which was successfully compiled for this FM.\nIt looks like this:\n" + FullLPMControlSequence);
 
       functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.HCAL_TTCCICONTROL,new StringT(FullLPMControlSequence)));
   }
@@ -874,31 +834,18 @@ public class HCALEventHandler extends UserEventHandler {
   // It can get the info from the userXML to find a sequence or parts of it from text files or the definition
   // can be done directly in the userXML.
   protected void getPIControl() {
-   String tmpPIControlSequence="";
-    // Load the master snippet from the found file and parse it.
+    String tmpPIControlSequence="";
     String selectedRun = ((StringT)functionManager.getParameterSet().get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-    logger.info("[HCAL " + functionManager.FMname + "]: The selected snippet was: " + selectedRun);    
+    logger.info("[Martin log HCAL " + functionManager.FMname + "]: This FM is going to parse PIControl seqence from : " +CfgCVSBasePath+ selectedRun+"/pro");    
     try{
-        docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-        if (selectedRun == "not set" ) {
-          logger.info("[HCAL " + functionManager.FMname + "]: This FM did not get the selected run. It will now look for one from the LVL1");
-          ParameterSet<FunctionManagerParameter> parameterSet = getUserFunctionManager().getParameterSet();
-          selectedRun = ((StringT)parameterSet.get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-          logger.info("[HCAL " + functionManager.FMname + "]: This FM looked for the selected run from the LVL1 and got: " + selectedRun);
-          if (selectedRun == "not set") {
-            ParameterSet<CommandParameter> commandParameterSet = getUserFunctionManager().getLastInput().getParameterSet();
-            selectedRun = ((StringT)commandParameterSet.get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-            logger.info("[HCAL " + functionManager.FMname + "]: This FM looked again for the selected run from the LVL1 and got: " + selectedRun);
-          }
-        }
         String TagName = "PIControl";
         tmpPIControlSequence = xmlHandler.getHCALControlSequence(selectedRun,CfgCVSBasePath,TagName);
     }
-    catch ( ParserConfigurationException |  UserActionException e) {
-          logger.error("[HCAL " + functionManager.FMname + "]: Got a error when parsing the PIControl xml: " + e.getMessage());
+    catch ( UserActionException e) {
+          logger.error("[Martin log HCAL " + functionManager.FMname + "]: Got a error when parsing the PIControl xml in getPIControl(): " + e.getMessage());
     }
     FullPIControlSequence = tmpPIControlSequence;
-    logger.info("[Martin Log HCAL " + functionManager.FMname + "] The FullPIControlSequence which was successfully compiled for this FM.\nIt looks like this:\n" + FullPIControlSequence);
+    logger.info("[Martin log HCAL " + functionManager.FMname + "] The FullPIControlSequence which was successfully compiled for this FM.\nIt looks like this:\n" + FullPIControlSequence);
 
      functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.HCAL_TTCCICONTROL,new StringT(FullPIControlSequence)));
   }

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -760,18 +760,6 @@ public class HCALEventHandler extends UserEventHandler {
     String selectedRun = ((StringT)functionManager.getParameterSet().get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
     logger.info("[HCAL " + functionManager.FMname + "]: This FM is going to parse TTCciControl seqence from : " +CfgCVSBasePath+ selectedRun+"/pro");    
     try{
-        docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-        if (selectedRun == "not set" ) {
-          logger.info("[HCAL " + functionManager.FMname + "]: This FM did not get the selected run. It will now look for one from the LVL1");
-          ParameterSet<FunctionManagerParameter> parameterSet = getUserFunctionManager().getParameterSet();
-          selectedRun = ((StringT)parameterSet.get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-          logger.info("[HCAL " + functionManager.FMname + "]: This FM looked for the selected run from the LVL1 and got: " + selectedRun);
-          if (selectedRun == "not set") {
-            ParameterSet<CommandParameter> commandParameterSet = getUserFunctionManager().getLastInput().getParameterSet();
-            selectedRun = ((StringT)commandParameterSet.get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-            logger.info("[HCAL " + functionManager.FMname + "]: This FM looked again for the selected run from the LVL1 and got: " + selectedRun);
-          }
-        }
         String TagName = "TTCciControl";
         tmpTTCciControlSequence = xmlHandler.getHCALControlSequence(selectedRun,CfgCVSBasePath,TagName);
     }

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -852,30 +852,51 @@ public class HCALEventHandler extends UserEventHandler {
   }
 
   // Function to "send" the FED_ENABLE_MASK aprameter to the HCAL supervisor application. It gets the info from the userXML.
+  //protected void getFedEnableMask(){
+  //  String FedEnableMask = GetUserXMLElement("FedEnableMask");
+  //  if (!FedEnableMask.equals("")){
+  //    logger.info("[HCAL " + functionManager.FMname + "] FedEnableMask in userXML found.\nHere is it:\n" + FedEnableMask);
+  //  }
+  //  else {
+  //    logger.info("[HCAL "+ functionManager.FMname + "] No FedEnableMask found in userXML.\n");
+  //  }
+  //  functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.FED_ENABLE_MASK,new StringT(FedEnableMask)));
+  //  //more logging stuff here...?
+  //}
+
+  // New getFEDEnableMask function, which looks for FEDEnableMask in mastersnippet
+  // This is used in local only
   protected void getFedEnableMask(){
-    String FedEnableMask = GetUserXMLElement("FedEnableMask");
-    if (!FedEnableMask.equals("")){
-      logger.info("[HCAL " + functionManager.FMname + "] FedEnableMask in userXML found.\nHere is it:\n" + FedEnableMask);
+    String FedEnableMask="";
+    String selectedRun = ((StringT)functionManager.getParameterSet().get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
+    logger.info("[Martin log HCAL " + functionManager.FMname + "]: This FM is going to parse FedEnableMask from : " +CfgCVSBasePath+ selectedRun+"/pro");    
+    try{
+        String TagName = "FedEnableMask";
+        FedEnableMask = xmlHandler.getHCALControlSequence(selectedRun,CfgCVSBasePath,TagName);
     }
-    else {
-      logger.info("[HCAL "+ functionManager.FMname + "] No FedEnableMask found in userXML.\n");
+    catch ( UserActionException e) {
+          logger.error("[Martin log HCAL " + functionManager.FMname + "]: Got a error when parsing the FedEnableMask in getFedEnableMask(): " + e.getMessage());
+    }
+    if (!FedEnableMask.equals("")){
+       logger.info("[Martin log HCAL " + functionManager.FMname + "] The FEDEnableMask which was successfully compiled for this FM.\nIt looks like this:\n" + FedEnableMask);
+    }else{
+       logger.info("[Martin log HCAL " + functionManager.FMname + "] No FedEnableMask found in mastersnippet.\n");
     }
     functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.FED_ENABLE_MASK,new StringT(FedEnableMask)));
-    //more logging stuff here...?
   }
 
   // Function to "send" the USE_PRIMARY_TCDS aprameter to the HCAL supervisor application. It gets the info from the userXML.
-  protected void getUsePrimaryTCDS(){
-    boolean UsePrimaryTCDS = Boolean.parseBoolean(GetUserXMLElement("UsePrimaryTCDS"));
-    if (GetUserXMLElement("UsePrimaryTCDS").equals("")){
-      logger.info("[HCAL " + functionManager.FMname + "] UsePrimaryTCDS in userXML found.\nHere is it:\n" + GetUserXMLElement("UsePrimaryTCDS"));
-    }
-    else {
-      logger.info("[HCAL "+ functionManager.FMname + "] No UsePrimaryTCDS found in userXML.\n");
-    }
-    functionManager.getParameterSet().put(new FunctionManagerParameter<BooleanT>(HCALParameters.USE_PRIMARY_TCDS,new BooleanT(UsePrimaryTCDS)));
-    // more logging stuff here...?
-  }
+  //protected void getUsePrimaryTCDS(){
+  //  boolean UsePrimaryTCDS = Boolean.parseBoolean(GetUserXMLElement("UsePrimaryTCDS"));
+  //  if (GetUserXMLElement("UsePrimaryTCDS").equals("")){
+  //    logger.info("[HCAL " + functionManager.FMname + "] UsePrimaryTCDS in userXML found.\nHere is it:\n" + GetUserXMLElement("UsePrimaryTCDS"));
+  //  }
+  //  else {
+  //    logger.info("[HCAL "+ functionManager.FMname + "] No UsePrimaryTCDS found in userXML.\n");
+  //  }
+  //  functionManager.getParameterSet().put(new FunctionManagerParameter<BooleanT>(HCALParameters.USE_PRIMARY_TCDS,new BooleanT(UsePrimaryTCDS)));
+  //  // more logging stuff here...?
+  //}
 
   // configuring all created HCAL applications by means of sending the HCAL CfgScript to the HCAL supervisor
   protected void sendRunTypeConfiguration(String CfgScript, String TTCciControlSequence, String LTCControlSequence, String TCDSControlSequence, String LPMControlSequence, String PIControlSequence, String FedEnableMask, boolean UsePrimaryTCDS) {

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -756,11 +756,10 @@ public class HCALEventHandler extends UserEventHandler {
   // can be done directly in the userXML.
   protected void getTTCciControl() {
     String tmpTTCciControlSequence="";
-    //try{
-        // Load the master snippet from the found file and parse it.
-        String selectedRun = ((StringT)functionManager.getParameterSet().get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
-        logger.info("[HCAL " + functionManager.FMname + "]: The selected snippet was: " + selectedRun);    
-      try{
+    // Load the master snippet from the found file and parse it.
+    String selectedRun = ((StringT)functionManager.getParameterSet().get(HCALParameters.RUN_CONFIG_SELECTED).getValue()).getString();
+    logger.info("[HCAL " + functionManager.FMname + "]: The selected snippet was: " + selectedRun);    
+    try{
         docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
         if (selectedRun == "not set" ) {
           logger.info("[HCAL " + functionManager.FMname + "]: This FM did not get the selected run. It will now look for one from the LVL1");
@@ -773,41 +772,12 @@ public class HCALEventHandler extends UserEventHandler {
             logger.info("[HCAL " + functionManager.FMname + "]: This FM looked again for the selected run from the LVL1 and got: " + selectedRun);
           }
         }
-          String TagName = "TTCciControl";
-          tmpTTCciControlSequence = xmlHandler.getHCALControlSequence(selectedRun,CfgCVSBasePath,TagName);
-       }
-       catch (  ParserConfigurationException |  UserActionException e) {
+        String TagName = "TTCciControl";
+        tmpTTCciControlSequence = xmlHandler.getHCALControlSequence(selectedRun,CfgCVSBasePath,TagName);
+    }
+    catch ( ParserConfigurationException |  UserActionException e) {
           logger.error("[HCAL " + functionManager.FMname + "]: Got a error when parsing the TTCciControl xml: " + e.getMessage());
-       }
-        
-      //  Document masterSnippet = docBuilder.parse(new File(CfgCVSBasePath + selectedRun + "/pro"));
-
-      //  masterSnippet.getDocumentElement().normalize();
-      //  DOMSource domSource = new DOMSource(masterSnippet);
-      //  StringWriter writer = new StringWriter();
-      //  StreamResult result = new StreamResult(writer);
-      //  TransformerFactory tf = TransformerFactory.newInstance();
-      //  Transformer transformer = tf.newTransformer();
-      //  transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-      //  transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-      //  transformer.transform(domSource, result);
-
-      //  NodeList TTCciControl =  masterSnippet.getDocumentElement().getElementsByTagName("TTCciControl");
-      //  logger.info("[Martin log HCAL " + functionManager.FMname + "]: Found " + TTCciControl.getLength()+" TTCciControl nodes ");
-
-      //  Element  el = (Element) TTCciControl.item(0);
-      //  NodeList childlist = el.getElementsByTagName("include");
-      //  logger.info("[Martin log HCAL " + functionManager.FMname + "]: Found " + childlist.getLength()+" cfg to read");
-      //  for(int i =0;i< childlist.getLength();i++){
-      //      Element iElement = (Element) childlist.item(i);
-      //      String fname = CfgCVSBasePath + iElement.getAttribute("file").substring(1)+"/pro";
-		  //      logger.info("Martin log [HCAL " + functionManager.FMname + "]: Going to read the file of this node from " + fname) ;
-      //      tmpTTCciControlSequence += readTextFile(fname); 
-      //  }
-      //}
-      //catch (TransformerException | DOMException | ParserConfigurationException | SAXException | IOException e) {
-      //    logger.error("[HCAL " + functionManager.FMname + "]: Got a error when parsing the TTCciControl xml: " + e.getMessage());
-      //}
+    }
     FullTTCciControlSequence = tmpTTCciControlSequence;
     logger.info("[Martin Log HCAL " + functionManager.FMname + "] The FullTTCciControlSequence which was successfully compiled for this FM.\nIt looks like this:\n" + FullTTCciControlSequence);
     functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.HCAL_TTCCICONTROL,new StringT(FullTTCciControlSequence)));

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -514,8 +514,9 @@ public class HCALEventHandler extends UserEventHandler {
         CfgCVSBasePath = DefaultCfgCVSBasePath;
       }
       //logger.debug("[HCAL base] CfgCVSBasePath: " +CfgCVSBasePath + " is used.");
-      logger.info("[HCAL base] CfgCVSBasePath: " +CfgCVSBasePath + " is used.");
-     
+      //logger.info("[HCAL ] CfgCVSBasePath: " +CfgCVSBasePath + " is used.");
+      logger.info("[Martin Log HCAL " + functionManager.FMname + "] The CfgCVSBasePath for this FM is " + CfgCVSBasePath);
+      functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.HCAL_CFGCVSBASEPATH,new StringT(CfgCVSBasePath)));
       
     }
 

--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -42,6 +42,8 @@ import java.util.Date;
 import java.util.TimeZone;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
+import java.net.URL;
+import java.net.MalformedURLException;
 
 import rcms.fm.fw.parameter.Parameter;
 import rcms.fm.fw.parameter.type.StringT;
@@ -217,6 +219,8 @@ public class HCALFunctionManager extends UserFunctionManager {
 
 	public HCALStateNotificationHandler theStateNotificationHandler = null;
 
+  public String rcmsStateListenerURL = "";
+
   public HCALFunctionManager() {
     // any State Machine Implementation must provide the framework with some information about itself.
 
@@ -280,6 +284,22 @@ public class HCALFunctionManager extends UserFunctionManager {
     DateFormat dateFormatter = new SimpleDateFormat("M/d/yy hh:mm:ss a z");
     dateFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));;
     utcFMtimeofstart = dateFormatter.format(FMtimeofstart);
+
+    // set statelistener URL
+    try {
+			URL fmURL = new URL(FMurl);
+			String rcmsStateListenerHost = fmURL.getHost();
+			int rcmsStateListenerPort = fmURL.getPort()+1;
+			String rcmsStateListenerProtocol = fmURL.getProtocol();
+			rcmsStateListenerURL = rcmsStateListenerProtocol+"://"+rcmsStateListenerHost+":"+rcmsStateListenerPort+"/rcms";
+		} catch (MalformedURLException e) {
+			String errMessage = "[HCAL " + FMname + "] Error! MalformedURLException in createAction" + e.getMessage();
+			logger.error(errMessage,e);
+			sendCMSError(errMessage);
+			getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.STATE,new StringT("Error")));
+			getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.ACTION_MSG,new StringT(errMessage)));
+			if (theEventHandler.TestMode.equals("off")) { firePriorityEvent(HCALInputs.SETERROR); ErrorState = true; return;}
+		}
 
     FMpartition = FMname.substring(5);
 
@@ -778,6 +798,55 @@ public class HCALFunctionManager extends UserFunctionManager {
 		}
 
 		return "";
+	}
+
+	/**----------------------------------------------------------------------
+<<<<<<< HEAD
+	 * go to the error state, setting messages and so forth, with exception
+	 */
+	public void goToError(String errMessage, Exception e) {
+		logger.error(errMessage,e);
+		sendCMSError(errMessage);
+		getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.STATE,new StringT("Error")));
+		getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.ACTION_MSG,new StringT("oops - technical difficulties ..."+errMessage)));
+		if (theEventHandler.TestMode.equals("off")) { firePriorityEvent(HCALInputs.SETERROR); ErrorState = true; }
+	}
+
+	/**----------------------------------------------------------------------
+	 * go to the error state, setting messages and so forth, without exception
+	 */
+	public void goToError(String errMessage) {
+		logger.error(errMessage);
+		sendCMSError(errMessage);
+		getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.STATE,new StringT("Error")));
+		getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.ACTION_MSG,new StringT("oops - technical difficulties ..."+errMessage)));
+		if (theEventHandler.TestMode.equals("off")) { firePriorityEvent(HCALInputs.SETERROR); ErrorState = true; }
+	}
+
+	/**----------------------------------------------------------------------
+	 * halt the LPM controller 
+	 */
+	public void haltLPMControllers() {
+		if (!containerlpmController.isEmpty()) {
+			XdaqApplication lpmApp = null;
+			try {
+				logger.debug("[HCAL LVL2 " + FMname + "] HALT LPM...");
+				Iterator it = containerlpmController.getQualifiedResourceList().iterator();
+				while (it.hasNext()) {
+					lpmApp = (XdaqApplication) it.next();
+          //XXX FIXME use real session ID here eventually
+					lpmApp.execute(HCALInputs.HALT,"test",rcmsStateListenerURL);
+				}
+			}
+			catch (Exception e) {
+				String errMessage = "[HCAL " + FMname + "] " + this.getClass().toString() + " failed HALT of lpm application: " + lpmApp.getName() + " class: " + lpmApp.getClass() + " instance: " + lpmApp.getInstance();
+				logger.error(errMessage,e);
+				sendCMSError(errMessage);
+				getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.STATE,new StringT("Error")));
+				getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.ACTION_MSG,new StringT("oops - technical difficulties ...")));
+				if (theEventHandler.TestMode.equals("off")) { firePriorityEvent(HCALInputs.SETERROR); ErrorState = true; return;}
+			}
+		}
 	}
 
 }

--- a/src/rcms/fm/app/level1/HCALParameters.java
+++ b/src/rcms/fm/app/level1/HCALParameters.java
@@ -79,6 +79,7 @@ public class HCALParameters {
 	public static final String TTS_TEST_SEQUENCE_REPEAT = "TTS_TEST_SEQUENCE_REPEAT";
 
 	// HCAL specific paramters
+	public static final String HCAL_CFGCVSBASEPATH    = "HCAL_CFGCVSBASEPATH";
 	public static final String HCAL_CFGSCRIPT    = "HCAL_CFGSCRIPT";
 	public static final String HCAL_TTCCICONTROL = "HCAL_TTCCICONTROL";
 	public static final String HCAL_LTCCONTROL = "HCAL_LTCCONTROL";
@@ -176,6 +177,12 @@ public class HCALParameters {
 		 * HCAL CfgScript
 		 */
 		GLOBAL_PARAMETER_SET.put(new FunctionManagerParameter<StringT>(HCAL_CFGSCRIPT, new StringT("not set"),FunctionManagerParameter.Exported.READONLY));
+
+		/**
+		 * HCAL CfgCVSBasePath
+		 */
+		GLOBAL_PARAMETER_SET.put(new FunctionManagerParameter<StringT>(HCAL_CFGCVSBASEPATH, new StringT("not set"),FunctionManagerParameter.Exported.READONLY));
+
 
 		/**
 		 * HCAL TTCci control sequence

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -659,12 +659,14 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
 			getPIControl();
 
 			// prepare run mode to be passed to level 2
+			String CfgCVSBasePath = ((StringT)functionManager.getParameterSet().get(HCALParameters.HCAL_CFGCVSBASEPATH).getValue()).getString();
 			ParameterSet<CommandParameter> pSet = new ParameterSet<CommandParameter>();
 			pSet.put(new CommandParameter<IntegerT>(HCALParameters.RUN_NUMBER, new IntegerT(functionManager.RunNumber)));
 			pSet.put(new CommandParameter<StringT>(HCALParameters.HCAL_RUN_TYPE, new StringT(RunType)));
 			pSet.put(new CommandParameter<StringT>(HCALParameters.RUN_KEY, new StringT(RunKey)));
 			pSet.put(new CommandParameter<StringT>(HCALParameters.TPG_KEY, new StringT(TpgKey)));
 			pSet.put(new CommandParameter<StringT>(HCALParameters.FED_ENABLE_MASK, new StringT(FedEnableMask)));
+			pSet.put(new CommandParameter<StringT>(HCALParameters.HCAL_CFGCVSBASEPATH, new StringT(CfgCVSBasePath)));
 			pSet.put(new CommandParameter<StringT>(HCALParameters.HCAL_CFGSCRIPT, new StringT(FullCfgScript)));
 			pSet.put(new CommandParameter<StringT>(HCALParameters.HCAL_TTCCICONTROL, new StringT(FullTTCciControlSequence)));
 			pSet.put(new CommandParameter<StringT>(HCALParameters.HCAL_LTCCONTROL, new StringT(FullLTCControlSequence)));

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -581,6 +581,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         // get the HCAL CfgCVSBasePath from LVL1 if the LVL1 has sent something
         if (parameterSet.get(HCALParameters.HCAL_CFGCVSBASEPATH) != null) {
           CfgCVSBasePath = ((StringT)parameterSet.get(HCALParameters.HCAL_CFGCVSBASEPATH).getValue()).getString();
+					functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.HCAL_CFGCVSBASEPATH,new StringT(CfgCVSBasePath)));
         }
         else {
           logger.info("[Martin log HCAL LVL2 " + functionManager.FMname + "]  Did not receive a LVL1 CfgCVSBasePath! This is OK if this FM do not look for files in CVS ");

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -629,7 +629,8 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       }
 
       if (LVL1TTCciControlSequence.equals("not set")) {
-        logger.info("[HCAL LVL2 " + functionManager.FMname + "] The LVL1 TTCci control sequence is not set.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a TTCci is not used in this config.");
+//        logger.info("[HCAL LVL2 " + functionManager.FMname + "] The LVL1 TTCci control sequence is not set.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a TTCci is not used in this config.");
+        logger.warn("[HCAL LVL2 " + functionManager.FMname + "] The LVL1 TTCci control sequence is not set. This is OK only ifa TTCci is not used in this config.");
       }
       else {
         FullTTCciControlSequence = LVL1TTCciControlSequence;
@@ -736,7 +737,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       }
 
       // compile TTCci control sequence incorporating the local definitions found in the UserXML
-      getTTCciControl();
+      //getTTCciControl();
 
       // compile LTC control sequence incorporating the local definitions found in the UserXML
       getLTCControl();
@@ -2415,7 +2416,8 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       }
 
       if (LVL1TTCciControlSequence.equals("not set")) {
-        logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! The LVL1 TTCci control sequence is not set.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a TTCci is not used in this config.");
+      //  logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! The LVL1 TTCci control sequence is not set.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a TTCci is not used in this config.");
+        logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! The LVL1 TTCci control sequence is not set.This is OOK only if a TTCci is not used in this config.");
       }
       else {
         FullTTCciControlSequence = LVL1TTCciControlSequence;
@@ -2434,7 +2436,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       getCfgScript();
 
       // compile TTCci control sequence incorporating the local definitions found in the UserXML
-      getTTCciControl();
+      //getTTCciControl();
 
       // compile LTC control sequence incorporating the local definitions found in the UserXML
       getLTCControl();

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -471,6 +471,11 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.STATE,new StringT("calculating state")));
       functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.ACTION_MSG,new StringT("configuring")));
 
+      //if (!functionManager.containerTTCciControl.isEmpty()) {
+      //  TTCciWatchThread ttcciwatchthread = new TTCciWatchThread(functionManager);
+      //  ttcciwatchthread.run();
+      //}
+     
       String LVL1CfgScript            = "not set";
       String LVL1TTCciControlSequence = "not set";
       String LVL1LTCControlSequence   = "not set";
@@ -1023,13 +1028,6 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
 
       }
 
-      // leave intermediate state directly only when not talking to asynchronous applications
-      if ( (!functionManager.asyncSOAP) && (!functionManager.ErrorState) ) {
-        if (!functionManager.getState().getStateString().equals(HCALStates.CONFIGURED.toString())) {
-          functionManager.fireEvent(HCALInputs.SETCONFIGURE);
-        }
-      }
-
       // set actions
       functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.STATE,new StringT(functionManager.getState().getStateString())));
       functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.ACTION_MSG,new StringT("configureAction executed ... - we're close ...")));
@@ -1571,7 +1569,6 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.ACTION_MSG,new StringT(errMessage)));
         if (TestMode.equals("off")) { functionManager.firePriorityEvent(HCALInputs.SETERROR); functionManager.ErrorState = true; return;}
       }
-
 
       if (!HCALSupervisorAsyncEnable) {
         // leave intermediate state only when not talking to asynchronous applications

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -476,6 +476,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       //  ttcciwatchthread.run();
       //}
      
+      String CfgCVSBasePath           = "not set";
       String LVL1CfgScript            = "not set";
       String LVL1TTCciControlSequence = "not set";
       String LVL1LTCControlSequence   = "not set";
@@ -574,6 +575,14 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
           logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Did not receive a FED list during the configureAction() - this is bad!");
         }
 
+        // get the HCAL CfgCVSBasePath from LVL1 if the LVL1 has sent something
+        if (parameterSet.get(HCALParameters.HCAL_CFGCVSBASEPATH) != null) {
+          CfgCVSBasePath = ((StringT)parameterSet.get(HCALParameters.HCAL_CFGCVSBASEPATH).getValue()).getString();
+        }
+        else {
+          logger.info("[Martin log HCAL LVL2 " + functionManager.FMname + "]  Did not receive a LVL1 CfgCVSBasePath! This is OK if this FM do not look for files in CVS ");
+        }
+
         // get the HCAL CfgScript from LVL1 if the LVL1 has sent something
         if (parameterSet.get(HCALParameters.HCAL_CFGSCRIPT) != null) {
           LVL1CfgScript = ((StringT)parameterSet.get(HCALParameters.HCAL_CFGSCRIPT).getValue()).getString();
@@ -618,6 +627,13 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         else {
           logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a LVL1 PI control sequence. This is OK only if a PI is not used in this config.");
         }
+      }
+
+      if (CfgCVSBasePath.equals("not set")) {
+        logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! The CfgCVSBasePath is not set in the LVL1! Check if LVL1 is passing it to LV2");
+      }
+      else {
+        logger.info("[HCAL LVL2 " + functionManager.FMname + "] CfgCVSBasePath was received.\nHere it is:\n" + CfgCVSBasePath);
       }
 
       if (LVL1CfgScript.equals("not set")) {
@@ -2359,6 +2375,15 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       if (parameterSet.size()!=0)  {
 
         // get the HCAL CfgScript from LVL1 if the LVL1 has sent something
+        if (parameterSet.get(HCALParameters.HCAL_CFGCVSBASEPATH) != null) {
+          CfgCVSBasePath = ((StringT)parameterSet.get(HCALParameters.HCAL_CFGCVSBASEPATH).getValue()).getString();
+        }
+        else {
+          logger.info("[Martin log HCAL LVL2 " + functionManager.FMname + "]  Did not receive a LVL1 CfgCVSBasePath! This is OK if this FM do not look for files in CVS ");
+        }
+
+
+        // get the HCAL CfgScript from LVL1 if the LVL1 has sent something
         if (parameterSet.get(HCALParameters.HCAL_CFGSCRIPT) != null) {
           LVL1CfgScript = ((StringT)parameterSet.get(HCALParameters.HCAL_CFGSCRIPT).getValue()).getString();
         }
@@ -2385,6 +2410,14 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         // set the function manager parameters
         functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.HCAL_RUN_TYPE,new StringT(RunType)));
       }
+
+      if (CfgCVSBasePath.equals("not set")) {
+        logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! The CfgCVSBasePath is not set in the LVL1! Check if LVL1 is passing it to LV2");
+      }
+      else {
+        logger.info("[HCAL LVL2 " + functionManager.FMname + "] CfgCVSBasePath was received.\nHere it is:\n" + CfgCVSBasePath);
+      }
+
 
       if (LVL1CfgScript.equals("not set")) {
         logger.error("[HCAL LVL2 " + functionManager.FMname + "] Warning! The LVL1CfgScript is not set in the LVL1! Check if LVL1 is passing it to LV2");

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -561,14 +561,14 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
           functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.SUPERVISOR_ERROR, new StringT(SupervisorError)));
         }
 
-        // get the FED list from the configure command
+        // get the FED list from the configure command in global run
         if (parameterSet.get(HCALParameters.FED_ENABLE_MASK) != null) {
           FedEnableMask = ((StringT)parameterSet.get(HCALParameters.FED_ENABLE_MASK).getValue()).getString();
           functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.FED_ENABLE_MASK,new StringT(FedEnableMask)));
           functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.CONFIGURED_WITH_FED_ENABLE_MASK,new StringT(FedEnableMask)));
           functionManager.HCALFedList = getEnabledHCALFeds(FedEnableMask);
 
-          logger.info("[HCAL LVL2 " + functionManager.FMname + "] ... did receive a FED list during the configureAction().");
+          logger.info("[HCAL LVL2 " + functionManager.FMname + "] ... did receive a FED list during the configureAction(). Here it is:\n "+ FedEnableMask);
         }
         else {
           logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Did not receive a FED list during the configureAction() - this is bad!");
@@ -732,9 +732,9 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         }
       }
 
-      // get the FedEnableMask found in the UserXML
+      // get the FedEnableMask from LV1
       if (functionManager.getParameterSet().get(HCALParameters.FED_ENABLE_MASK) != null && ((StringT)functionManager.getParameterSet().get(HCALParameters.FED_ENABLE_MASK).getValue()).getString() == "") {
-        getFedEnableMask();
+        //getFedEnableMask();
         FedEnableMask = ((StringT)functionManager.getParameterSet().get(HCALParameters.FED_ENABLE_MASK).getValue()).getString();
         logger.info("[HCAL LVL2 " + functionManager.FMname + "] The FED_ENABLE_MASK to be sent to the hcalSupervisor is: " + FedEnableMask);
       }

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -579,7 +579,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
           LVL1CfgScript = ((StringT)parameterSet.get(HCALParameters.HCAL_CFGSCRIPT).getValue()).getString();
         }
         else {
-          logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a LVL1 CfgScript.\nThis is OK if each LVL2 (i.e.also this one) has such a CfgScript defined itself.");
+          logger.error("[HCAL LVL2 " + functionManager.FMname + "] Did not receive a LVL1 CfgScript! Check if the LV1 is passing to it.");
         }
 
         // get the HCAL TTCciControl from LVL1 if the LVL1 has sent something
@@ -587,7 +587,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
           LVL1TTCciControlSequence = ((StringT)parameterSet.get(HCALParameters.HCAL_TTCCICONTROL).getValue()).getString();
         }
         else {
-          logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a LVL1 TTCci control sequence.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a TTCci is not used in this config.");
+          logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a LVL1 TTCci control sequence. This is OK only if a TTCci is not used in this config.");
         }
 
         // get the HCAL LTCControl from LVL1 if the LVL1 has sent something
@@ -595,33 +595,33 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
           LVL1LTCControlSequence = ((StringT)parameterSet.get(HCALParameters.HCAL_LTCCONTROL).getValue()).getString();
         }
         else {
-          logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a LVL1 LTC control sequence.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a LTC is not used in this config.");
+          logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a LVL1 LTC control sequence. This is OK only if a LTC is not used in this config.");
         }
         // get the HCAL TCDSControl from LVL1 if the LVL1 has sent something
         if (parameterSet.get(HCALParameters.HCAL_TCDSCONTROL) != null) {
           LVL1TCDSControlSequence = ((StringT)parameterSet.get(HCALParameters.HCAL_TCDSCONTROL).getValue()).getString();
         }
         else {
-          logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a LVL1 TCDS control sequence.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a TCDS is not used in this config.");
+          logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a LVL1 TCDS control sequence.This is OK only if a TCDS is not used in this config.");
         }
         // get the HCAL LPMControl from LVL1 if the LVL1 has sent something
         if (parameterSet.get(HCALParameters.HCAL_LPMCONTROL) != null) {
           LVL1LPMControlSequence = ((StringT)parameterSet.get(HCALParameters.HCAL_LPMCONTROL).getValue()).getString();
         }
         else {
-          logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a LVL1 LPM control sequence.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a LPM is not used in this config.");
+          logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a LVL1 LPM control sequence. This is OK only if a LPM is not used in this config.");
         }
         // get the HCAL PIControl from LVL1 if the LVL1 has sent something
         if (parameterSet.get(HCALParameters.HCAL_PICONTROL) != null) {
           LVL1PIControlSequence = ((StringT)parameterSet.get(HCALParameters.HCAL_PICONTROL).getValue()).getString();
         }
         else {
-          logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a LVL1 PI control sequence.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a PI is not used in this config.");
+          logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a LVL1 PI control sequence. This is OK only if a PI is not used in this config.");
         }
       }
 
       if (LVL1CfgScript.equals("not set")) {
-        logger.info("[HCAL LVL2 " + functionManager.FMname + "] The LVL1CfgScript is not set.\nThis is OK if this LVL2 has such a CfgScript defined itself.");
+        logger.error("[HCAL LVL2 " + functionManager.FMname + "] The LVL1CfgScript is not set. Check if the LV1 is passing to it.");
       }
       else {
         FullCfgScript = LVL1CfgScript;
@@ -629,8 +629,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       }
 
       if (LVL1TTCciControlSequence.equals("not set")) {
-//        logger.info("[HCAL LVL2 " + functionManager.FMname + "] The LVL1 TTCci control sequence is not set.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a TTCci is not used in this config.");
-        logger.warn("[HCAL LVL2 " + functionManager.FMname + "] The LVL1 TTCci control sequence is not set. This is OK only ifa TTCci is not used in this config.");
+        logger.info("[HCAL LVL2 " + functionManager.FMname + "] The LVL1 TTCci control sequence is not set. This is OK only if a TTCci is not used in this config.");
       }
       else {
         FullTTCciControlSequence = LVL1TTCciControlSequence;
@@ -638,7 +637,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       }
 
       if (LVL1LTCControlSequence.equals("not set")) {
-        logger.info("[HCAL LVL2 " + functionManager.FMname + "] The LVL1 LTC control sequence is not set.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a LTC is not used in this config.");
+        logger.info("[HCAL LVL2 " + functionManager.FMname + "] The LVL1 LTC control sequence is not set. This is OK only if a LTC is not used in this config.");
       }
       else {
         FullLTCControlSequence = LVL1LTCControlSequence;
@@ -646,7 +645,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       }
 
       if (LVL1TCDSControlSequence.equals("not set")) {
-        logger.info("[HCAL LVL2 " + functionManager.FMname + "] The LVL1 TCDS control sequence is not set.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a TCDS is not used in this config.");
+        logger.info("[HCAL LVL2 " + functionManager.FMname + "] The LVL1 TCDS control sequence is not set. This is OK only if a TCDS is not used in this config.");
       }
       else {
         FullTCDSControlSequence = LVL1TCDSControlSequence;
@@ -654,7 +653,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       }
 
       if (LVL1LPMControlSequence.equals("not set")) {
-        logger.info("[HCAL LVL2 " + functionManager.FMname + "] The LVL1 LPM control sequence is not set.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a LPM is not used in this config.");
+        logger.info("[HCAL LVL2 " + functionManager.FMname + "] The LVL1 LPM control sequence is not set. This is OK only if a LPM is not used in this config.");
       }
       else {
         FullLPMControlSequence = LVL1LPMControlSequence;
@@ -662,7 +661,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       }
 
       if (LVL1PIControlSequence.equals("not set")) {
-        logger.info("[HCAL LVL2 " + functionManager.FMname + "] The LVL1 PI control sequence is not set.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a PI is not used in this config.");
+        logger.info("[HCAL LVL2 " + functionManager.FMname + "] The LVL1 PI control sequence is not set. This is OK only if a PI is not used in this config.");
       }
       else {
         FullPIControlSequence = LVL1PIControlSequence;
@@ -740,16 +739,16 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       //getTTCciControl();
 
       // compile LTC control sequence incorporating the local definitions found in the UserXML
-      getLTCControl();
+      //getLTCControl();
 
       // compile TCDS control sequence incorporating the local definitions found in the UserXML
-      getTCDSControl();
+      //getTCDSControl();
 
       // compile LPM control sequence incorporating the local definitions found in the UserXML
-      getLPMControl();
+      //getLPMControl();
 
       // compile LPM control sequence incorporating the local definitions found in the UserXML
-      getPIControl();
+      //getPIControl();
 
 
       // get the FedEnableMask found in the UserXML
@@ -2383,7 +2382,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
           LVL1CfgScript = ((StringT)parameterSet.get(HCALParameters.HCAL_CFGSCRIPT).getValue()).getString();
         }
         else {
-          logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a LVL1 CfgScript.\nThis is OK if each LVL2 (i.e.also this one) has such a CfgScript defined itself.");
+          logger.error("[HCAL LVL2 " + functionManager.FMname + "]  Did not receive a LVL1 CfgScript! Check if LVL1 is passing it to LV2");
         }
 
         // get the HCAL TTCciControl from LVL1 if the LVL1 has sent something
@@ -2391,7 +2390,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
           LVL1TTCciControlSequence = ((StringT)parameterSet.get(HCALParameters.HCAL_TTCCICONTROL).getValue()).getString();
         }
         else {
-          logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a LVL1 TTCci control sequence.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a TTCci is not used in this config.");
+          logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a LVL1 TTCci control sequence. This is OK only if a TTCci is not used in this config.");
         }
 
         // get the HCAL LTCControl from LVL1 if the LVL1 has sent something
@@ -2399,7 +2398,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
           LVL1LTCControlSequence = ((StringT)parameterSet.get(HCALParameters.HCAL_LTCCONTROL).getValue()).getString();
         }
         else {
-          logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a LVL1 LTC control sequence.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a LTC is not used in this config.");
+          logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a LVL1 LTC control sequence. This is OK only if a LTC is not used in this config.");
         }
 
         // set the function manager parameters
@@ -2407,7 +2406,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       }
 
       if (LVL1CfgScript.equals("not set")) {
-        logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! The LVL1CfgScript is not set.\nThis is OK if this LVL2 has such a CfgScript defined itself.");
+        logger.error("[HCAL LVL2 " + functionManager.FMname + "] Warning! The LVL1CfgScript is not set in the LVL1! Check if LVL1 is passing it to LV2");
       }
       else {
         FullCfgScript = LVL1CfgScript;
@@ -2415,8 +2414,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       }
 
       if (LVL1TTCciControlSequence.equals("not set")) {
-      //  logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! The LVL1 TTCci control sequence is not set.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a TTCci is not used in this config.");
-        logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! The LVL1 TTCci control sequence is not set.This is OOK only if a TTCci is not used in this config.");
+        logger.info("[HCAL LVL2 " + functionManager.FMname + "] Warning! The LVL1 TTCci control sequence is not set. This is OK only if a TTCci is not used in this config.");
       }
       else {
         FullTTCciControlSequence = LVL1TTCciControlSequence;
@@ -2424,21 +2422,12 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       }
 
       if (LVL1LTCControlSequence.equals("not set")) {
-        logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Warning! The LVL1 LTC control sequence is not set.\nThis is OK if either each LVL2 (i.e.also this one) has such a sequence defined itself or a LTC is not used in this config.");
+        logger.info("[HCAL LVL2 " + functionManager.FMname + "] Warning! The LVL1 LTC control sequence is not set.\nThis is OK only if a LTC is not used in this config.");
       }
       else {
         FullLTCControlSequence = LVL1LTCControlSequence;
         logger.info("[HCAL LVL2 " + functionManager.FMname + "] LVL1 LTC control sequence was received.\nHere it is:\n" + FullLTCControlSequence);
       }
-
-      // compile CfgScript incorporating the local definitions found in the UserXML
-      getCfgScript();
-
-      // compile TTCci control sequence incorporating the local definitions found in the UserXML
-      //getTTCciControl();
-
-      // compile LTC control sequence incorporating the local definitions found in the UserXML
-      getLTCControl();
 
       // configuring all created HCAL applications by means of sending the RunType to the HCAL supervisor
       sendRunTypeConfiguration(FullCfgScript,FullTTCciControlSequence,FullLTCControlSequence,FullTCDSControlSequence,FullLPMControlSequence,FullPIControlSequence,FedEnableMask,UsePrimaryTCDS);
@@ -2537,7 +2526,6 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         logger.error(errMessage);
         functionManager.sendCMSError(errMessage);
         if (TestMode.equals("off")) { functionManager.firePriorityEvent(HCALInputs.SETERROR); functionManager.ErrorState = true; return;}
-
       }
 
       // leave intermediate state

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -888,13 +888,14 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
           XDAQParameter pam = null;
           pam =((XdaqApplication)qr).getXDAQParameter();
 
-          pam.select(new String[] {"IsLocalRun", "TriggerKey", "ReportStateToRCMS"});
+          pam.select(new String[] {"IsLocalRun", "TriggerKey", "ReportStateToRCMS","HaltLPM"});
           pam.setValue("IsLocalRun", String.valueOf(RunType.equals("local")));
           logger.info("[HCAL " + functionManager.FMname + "] Set IsLocalRun to: " + String.valueOf(RunType.equals("local")));
           pam.setValue("TriggerKey", TpgKey);
           pam.setValue("ReportStateToRCMS", "true");
           logger.info("[HCAL " + functionManager.FMname + "] Set ReportStateToRCMS to: true.");
-
+          pam.setValue("HaltLPM", "false");
+          logger.info("[HCAL " + functionManager.FMname + "] Set HaltLPM to: false.");
           pam.send();
         }
         catch (XDAQTimeoutException e) {

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -889,14 +889,13 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
           XDAQParameter pam = null;
           pam =((XdaqApplication)qr).getXDAQParameter();
 
-          pam.select(new String[] {"IsLocalRun", "TriggerKey", "ReportStateToRCMS","HaltLPM"});
+          pam.select(new String[] {"IsLocalRun", "TriggerKey", "ReportStateToRCMS"});
           pam.setValue("IsLocalRun", String.valueOf(RunType.equals("local")));
           logger.info("[HCAL " + functionManager.FMname + "] Set IsLocalRun to: " + String.valueOf(RunType.equals("local")));
           pam.setValue("TriggerKey", TpgKey);
           pam.setValue("ReportStateToRCMS", "true");
           logger.info("[HCAL " + functionManager.FMname + "] Set ReportStateToRCMS to: true.");
-          pam.setValue("HaltLPM", "false");
-          logger.info("[HCAL " + functionManager.FMname + "] Set HaltLPM to: false.");
+
           pam.send();
         }
         catch (XDAQTimeoutException e) {

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -709,9 +709,6 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         logger.debug("[HCAL LVL2 " + functionManager.FMname + "] No special VdM scan snippets, etc. enabled for this FM.\nThe RUN_KEY given is: " + RunKey);
       }
 
-      // compile CfgScript incorporating the local definitions found in the UserXML
-      getCfgScript();
-
       if (TpgKey!=null && TpgKey!="NULL") {
 
         FullCfgScript += "\n### BEGIN TPG key add from HCAL FM named: " + functionManager.FMname + "\n";
@@ -734,22 +731,6 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
           logger.error("[HCAL LVL2 " + functionManager.FMname + "] Error! For global runs we should have received a TPG_KEY.\nPlease check if HCAL is in the trigger.\n If HCAL is in the trigger and you see this message please call an expert - this is bad!!");
         }
       }
-
-      // compile TTCci control sequence incorporating the local definitions found in the UserXML
-      //getTTCciControl();
-
-      // compile LTC control sequence incorporating the local definitions found in the UserXML
-      //getLTCControl();
-
-      // compile TCDS control sequence incorporating the local definitions found in the UserXML
-      //getTCDSControl();
-
-      // compile LPM control sequence incorporating the local definitions found in the UserXML
-      //getLPMControl();
-
-      // compile LPM control sequence incorporating the local definitions found in the UserXML
-      //getPIControl();
-
 
       // get the FedEnableMask found in the UserXML
       if (functionManager.getParameterSet().get(HCALParameters.FED_ENABLE_MASK) != null && ((StringT)functionManager.getParameterSet().get(HCALParameters.FED_ENABLE_MASK).getValue()).getString() == "") {

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -163,7 +163,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
             //String newExecXML = intermediateXML;
             //TODO
             //if (functionManager.FMrole.equals("EvmTrig") && !addedContext) {
-            String newExecXML = xmlHandler.addStateListenerContext(intermediateXML, functionManager.FMurl);
+            String newExecXML = xmlHandler.addStateListenerContext(intermediateXML, functionManager.rcmsStateListenerURL);
             //  addedContext = true;
               System.out.println("Set the statelistener context.");
             //}
@@ -190,7 +190,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       }
 
       // initialize all XDAQ executives
-      // we also halt the TCDS applications here
+      // we also halt the LPM applications inside here
       initXDAQ();
 
       String ruInstance = "";
@@ -386,6 +386,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       destroyXDAQ();
 
       // init all XDAQ executives
+      // also halt all LPM applications inside here
       initXDAQ();
 
       // go to Halted
@@ -444,6 +445,8 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.ACTION_MSG,new StringT(errMessage)));
         if (TestMode.equals("off")) { functionManager.firePriorityEvent(HCALInputs.SETERROR); functionManager.ErrorState = true; return;}
       }
+			// halt LPM
+			functionManager.haltLPMControllers();
 
       // leave intermediate state directly only when not talking to asynchronous applications
       if ( (!functionManager.asyncSOAP) && (!functionManager.ErrorState) ) {
@@ -1941,6 +1944,9 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
            }
            }
            */
+        // halt LPM
+        functionManager.haltLPMControllers();
+
         // stop the StorageManagers
         if (!functionManager.containerStorageManager.isEmpty()) {
           try {

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -306,8 +306,8 @@ public class HCALxmlHandler {
         NodeList childlist = el.getElementsByTagName("include"); 
         for(int iFile=0; iFile< childlist.getLength() ; iFile++){
            Element iElement = (Element) childlist.item(iFile);
-           String fname = CfgCVSBasePath + iElement.getAttribute("file").substring(1)+"/pro";
-		       logger.info("Martin log [HCAL " + functionManager.FMname + "]: Going to read the file of this node from " + fname) ;
+           String fname = CfgCVSBasePath + iElement.getAttribute("file").substring(1)+"/"+ iElement.getAttribute("version");
+		       logger.info("[Martin log HCAL " + functionManager.FMname + "]: Going to read the file of this node from " + fname) ;
            tmpCtrlSequence += readFile(fname,Charset.defaultCharset());
         }
     }

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -298,7 +298,6 @@ public class HCALxmlHandler {
 
         //NodeList TTCciControl =  masterSnippet.getDocumentElement().getElementsByTagName("TTCciControl");
         NodeList CtrlSequence =  masterSnippet.getDocumentElement().getElementsByTagName(CtrlSequenceTagName);
-        logger.info("[Martin log HCAL " + functionManager.FMname + "]: Found " + CtrlSequence.getLength()+ " "+ CtrlSequenceTagName+ " nodes ");
         if (CtrlSequence.getLength()>1){
             logger.warn("[Martin log HCAL " + functionManager.FMname + "]: Found more than one ctrl sequence of "+ CtrlSequenceTagName+ " in mastersnippet. Only the first one will be used ");
         }else if (CtrlSequence.getLength()==0){

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -301,15 +301,21 @@ public class HCALxmlHandler {
         logger.info("[Martin log HCAL " + functionManager.FMname + "]: Found " + CtrlSequence.getLength()+ " "+ CtrlSequenceTagName+ " nodes ");
         if (CtrlSequence.getLength()>1){
             logger.warn("[Martin log HCAL " + functionManager.FMname + "]: Found more than one ctrl sequence of "+ CtrlSequenceTagName+ " in mastersnippet. Only the first one will be used ");
-        }
-        Element el = (Element) CtrlSequence.item(0);
-        NodeList childlist = el.getElementsByTagName("include"); 
-        for(int iFile=0; iFile< childlist.getLength() ; iFile++){
-           Element iElement = (Element) childlist.item(iFile);
-           String fname = CfgCVSBasePath + iElement.getAttribute("file").substring(1)+"/"+ iElement.getAttribute("version");
-		       logger.info("[Martin log HCAL " + functionManager.FMname + "]: Going to read the file of this node from " + fname) ;
-           tmpCtrlSequence += readFile(fname,Charset.defaultCharset());
-        }
+        }else if (CtrlSequence.getLength()==0){
+            logger.warn("[Martin log HCAL " + functionManager.FMname + "]: Cannot find "+ CtrlSequenceTagName+ " in mastersnippet. Empty string will be returned. ");
+            return tmpCtrlSequence;
+        }else if (CtrlSequence.getLength()==1){
+           logger.info("[Martin log HCAL " + functionManager.FMname + "]: Found 1 "+ CtrlSequenceTagName+ " in mastersnippet. Going to parse it. ");
+
+           Element el = (Element) CtrlSequence.item(0);
+           NodeList childlist = el.getElementsByTagName("include"); 
+           for(int iFile=0; iFile< childlist.getLength() ; iFile++){
+               Element iElement = (Element) childlist.item(iFile);
+               String fname = CfgCVSBasePath + iElement.getAttribute("file").substring(1)+"/"+ iElement.getAttribute("version");
+		           logger.info("[Martin log HCAL " + functionManager.FMname + "]: Going to read the file of this node from " + fname) ;
+               tmpCtrlSequence += readFile(fname,Charset.defaultCharset());
+           }
+				}
     }
     catch (TransformerException | DOMException | ParserConfigurationException | SAXException | IOException e) {
         logger.error("[HCAL " + functionManager.FMname + "]: Got a error when parsing the "+ CtrlSequenceTagName +" xml: " + e.getMessage());

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -298,19 +298,17 @@ public class HCALxmlHandler {
 
         //NodeList TTCciControl =  masterSnippet.getDocumentElement().getElementsByTagName("TTCciControl");
         NodeList CtrlSequence =  masterSnippet.getDocumentElement().getElementsByTagName(CtrlSequenceTagName);
-        logger.info("[HCAL " + functionManager.FMname + "]: The " + CtrlSequenceTagName + " has this in it:");
-        logger.info("[HCAL " + functionManager.FMname + "]: ---------------------------");
-        String TTCciControlDoc = CtrlSequence.item(0).getTextContent();
-        logger.info(TTCciControlDoc);
-        logger.info("[HCAL " + functionManager.FMname + "]: ---------------------------");
-
-        for(int iFile=0; iFile< CtrlSequence.getLength() ; iFile++){
-           Node iNode = CtrlSequence.item(iFile);
-           Element iElement = (Element) iNode;
-           if (iElement.getTagName()=="include"){
-               String fname = CfgCVSBasePath + iElement.getAttribute("file").substring(1)+"/pro";
-               tmpCtrlSequence += readFile(fname,Charset.defaultCharset());
-           }
+        logger.info("[Martin log HCAL " + functionManager.FMname + "]: Found " + CtrlSequence.getLength()+ " "+ CtrlSequenceTagName+ " nodes ");
+        if (CtrlSequence.getLength()>1){
+            logger.warn("[Martin log HCAL " + functionManager.FMname + "]: Found more than one ctrl sequence of "+ CtrlSequenceTagName+ " in mastersnippet. Only the first one will be used ");
+        }
+        Element el = (Element) CtrlSequence.item(0);
+        NodeList childlist = el.getElementsByTagName("include"); 
+        for(int iFile=0; iFile< childlist.getLength() ; iFile++){
+           Element iElement = (Element) childlist.item(iFile);
+           String fname = CfgCVSBasePath + iElement.getAttribute("file").substring(1)+"/pro";
+		       logger.info("Martin log [HCAL " + functionManager.FMname + "]: Going to read the file of this node from " + fname) ;
+           tmpCtrlSequence += readFile(fname,Charset.defaultCharset());
         }
     }
     catch (TransformerException | DOMException | ParserConfigurationException | SAXException | IOException e) {

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -229,14 +229,10 @@ public class HCALxmlHandler {
       throw new UserActionException("[HCAL " + functionManager.FMname + "]: Got an error while parsing an XDAQ executive's configurationXML: " + e.getMessage());
     }
   }  
-  public String addStateListenerContext(String execXMLstring, String fmURLString) throws UserActionException{
+  public String addStateListenerContext(String execXMLstring, String rcmsStateListenerURL) throws UserActionException{
     logger.info("[JohnLog] " + functionManager.FMname + ": adding the RCMStateListener context to the executive xml.");   
     String newExecXMLstring = "";
     try {
-			URL fmURL = new URL(fmURLString);
-			String rcmsStateListenerHost = fmURL.getHost();
-			int rcmsStateListenerPort = fmURL.getPort()+1;
-			String rcmsStateListenerProtocol = fmURL.getProtocol();
 
       System.out.println(execXMLstring);
       docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
@@ -250,7 +246,7 @@ public class HCALxmlHandler {
       //stateListenerContext.setAttribute("url", "http://cmsrc-hcal.cms:16001/rcms");
       //stateListenerContext.setAttribute("url", "http://cmshcaltb02.cern.ch:16001/rcms");
 			//logger.info("[SethLog] " + functionManager.FMname + ": adding the RCMStateListener with url: " + rcmsStateListenerProtocol+"://"+rcmsStateListenerHost+":"+rcmsStateListenerPort+"/rcms" );
-      stateListenerContext.setAttribute("url", rcmsStateListenerProtocol+"://"+rcmsStateListenerHost+":"+rcmsStateListenerPort+"/rcms");
+      stateListenerContext.setAttribute("url", rcmsStateListenerURL);
       Element stateListenerApp=execXML.createElement("xc:Application");
       stateListenerApp.setAttribute("class", "RCMSStateListener");
       stateListenerApp.setAttribute("id", "50");

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -322,6 +322,41 @@ public class HCALxmlHandler {
     String FullCtrlSequence = tmpCtrlSequence;
     return FullCtrlSequence;
   }
+  public String getHCALMasterSnippetTag(String selectedRun, String CfgCVSBasePath, String TagName) throws UserActionException{
+    String TagContent ="";
+    try{
+        // Get ControlSequences from mastersnippet
+        docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        Document masterSnippet = docBuilder.parse(new File(CfgCVSBasePath + selectedRun + "/pro"));
+
+        masterSnippet.getDocumentElement().normalize();
+        DOMSource domSource = new DOMSource(masterSnippet);
+        StringWriter writer = new StringWriter();
+        StreamResult result = new StreamResult(writer);
+        TransformerFactory tf = TransformerFactory.newInstance();
+        Transformer transformer = tf.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+        transformer.transform(domSource, result);
+
+        //NodeList TTCciControl =  masterSnippet.getDocumentElement().getElementsByTagName("TTCciControl");
+        NodeList TagNodeList =  masterSnippet.getDocumentElement().getElementsByTagName(TagName);
+        if (TagNodeList.getLength()>1){
+            logger.warn("[Martin log HCAL " + functionManager.FMname + "]: Found more than one ctrl sequence of "+ TagName+ " in mastersnippet. Only the first one will be used ");
+        }else if (TagNodeList.getLength()==0){
+            logger.warn("[Martin log HCAL " + functionManager.FMname + "]: Cannot find "+ TagName+ " in mastersnippet. Empty string will be returned. ");
+            return TagContent;
+        }else if (TagNodeList.getLength()==1){
+           logger.info("[Martin log HCAL " + functionManager.FMname + "]: Found 1 "+ TagName+ " in mastersnippet. Going to parse it. "); 
+           TagContent = TagNodeList.item(0).getTextContent();
+				}
+    }
+    catch (TransformerException | DOMException | ParserConfigurationException | SAXException | IOException e) {
+        logger.error("[HCAL " + functionManager.FMname + "]: Got a error when parsing the "+ TagName +" xml: " + e.getMessage());
+    }
+    return TagContent;
+  }
+
   static String readFile(String path, Charset encoding) throws IOException {
       byte[] encoded = Files.readAllBytes(Paths.get(path));
       return new String(encoded, encoding);


### PR DESCRIPTION
This should include:
- Complete removal of ACP: 
   LV2 now does not parse anything during config action now. They receive the parameters from LV1.
- Add error sending function; (Seth)
   add state polling for supervisor (catches, e.g., early errors on configure).
- Halt LPM(s) where needed (Seth)
- Watch Thread part was removed.